### PR TITLE
fix: RetryHandler response leak, 4xx retry storm, and async void test

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,4 @@
 {
-    "pkgRoot": "dist_ts",
     "branches": [
         "main"
     ],

--- a/OpenMeteo.Tests/UnitTest1.cs
+++ b/OpenMeteo.Tests/UnitTest1.cs
@@ -4,7 +4,7 @@ using OpenMeteo;
 public class UnitTest1
 {
     [Fact]
-    public async void Test1()
+    public async Task Test1()
     {
         var client = new OpenMeteoClient();
         var uri = new Uri("https://api.open-meteo.com/v1/forecast?latitude=52.52&longitude=13.41&hourly=temperature_2m,windspeed_10m&daily=temperature_2m_max,temperature_2m_min&format=flatbuffers&timezone=auto");

--- a/OpenMeteo/OpenMeteo.cs
+++ b/OpenMeteo/OpenMeteo.cs
@@ -96,29 +96,30 @@ namespace OpenMeteo
             HttpResponseMessage response = null;
             for (int i = 0; i < MaxRetries; i++)
             {
+                response?.Dispose();
                 response = await base.SendAsync(request, cancellationToken);
                 if (response.IsSuccessStatusCode)
                 {
                     return response;
                 }
+                if ((int)response.StatusCode < 500)
+                {
+                    return response;
+                }
                 int waitMs = (int)Math.Min(BackoffFactor * Math.Pow(2, i), BackoffMaxSeconds) * 1000;
-                await Task.Delay(waitMs);
+                try
+                {
+                    await Task.Delay(waitMs, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    response.Dispose();
+                    throw;
+                }
             }
             return response;
         }
     }
 
-    /*public static class VariablesWithTimeExtension {
-        /// <summary>
-        /// Iterate over timestamps
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static IEnumerable<DateTimeOffset> DateTimeEnumerator(this VariablesWithTime value)
-        {
-            for (var time = value.Time; time < value.TimeEnd; time += value.Interval)
-                yield return DateTimeOffset.FromUnixTimeSeconds(time);
-        }
-    }*/
 }
 


### PR DESCRIPTION
Noticed a few issues:

- RetryHandler was leaking HttpResponseMessage objects - every failed attempt got overwritten without being disposed. If you cancelled during a retry delay, that response leaked too. Fixed with response?.Dispose() + catching OperationCanceledException to clean up before rethrowing.

- Handler was also retrying 4xx errors - 404s, 401s, 429s all got retried 3 times. That's just wasting requests and getting you rate-limited faster. Changed to only retry on server errors (5xx).

- Test had async void - one unhandled exception and it takes down the whole test runner. Changed to async Task.

- Removed dead commented-out code (VariablesWithTimeExtension) and a stale "pkgRoot": "dist_ts" in .releaserc.json that was left over from a JS project copy-paste.

No API changes, fully backward compatible.